### PR TITLE
Feature/set config

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
+        "confy",
         "moonenv",
         "Runtimes"
     ],

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,3 +11,4 @@ serde_json = "1.0.117"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 base64 = "0.22.1"
+confy = {version = "0.6.1", features = ["yaml_conf"], default-features = false}

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,3 +12,4 @@ serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
 base64 = "0.22.1"
 confy = {version = "0.6.1", features = ["yaml_conf"], default-features = false}
+dirs = "5.0.1"

--- a/cli/src/cli_struct.rs
+++ b/cli/src/cli_struct.rs
@@ -17,8 +17,9 @@ pub enum Command {
     /// Pushed the .env file located on the path where the command has been executed to the repository
     Push(RepoActionEnvArgs),
 
+    #[clap(subcommand)]
     /// Changes the application's configuration settings.
-    Config(ConfigVariable),
+    Config(ConfigVariableOptions),
 }
 
 #[derive(Clone, ValueEnum, Debug, Serialize)]
@@ -50,8 +51,19 @@ pub struct RepoActionEnvArgs {
     pub env: Environment,
 }
 
+#[derive(Subcommand, Debug)]
+pub enum ConfigVariableOptions {
+    /// Creates or updates a profile with specified settings.
+    /// Use this command to either create a new profile or update an existing one with new values.
+    Upsert(ConfigVariableUpsert),
+
+    /// Sets the currently selected profile as the default for the application.
+    /// This command will modify the application's settings so that the specified profile
+    Default(ConfigVariableChangeDefault),
+}
+
 #[derive(Args, Debug)]
-pub struct ConfigVariable {
+pub struct ConfigVariableUpsert {
     /// A friendly name for identifying this configuration.
     pub name: String,
 
@@ -59,4 +71,10 @@ pub struct ConfigVariable {
     /// The full URL to the server.
     /// If provided, it should be a valid URL format, e.g., "https://example.com".
     pub url: Option<String>,
+}
+
+#[derive(Args, Debug)]
+pub struct ConfigVariableChangeDefault {
+    /// The name of the profile to set as default.
+    pub name: String,
 }

--- a/cli/src/cli_struct.rs
+++ b/cli/src/cli_struct.rs
@@ -1,5 +1,5 @@
 use clap::{Args, Parser, Subcommand, ValueEnum};
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 use std::fmt;
 
 /// Manages environment helping saving and pulling it
@@ -9,16 +9,6 @@ pub struct App {
     pub command: Command,
 }
 
-#[derive(Deserialize, Debug)]
-pub struct PushResponse {
-    pub message: String,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct PullResponse {
-    pub file: String,
-}
-
 #[derive(Subcommand, Debug)]
 pub enum Command {
     /// Pulls the .env from the indicated repository
@@ -26,6 +16,9 @@ pub enum Command {
 
     /// Pushed the .env file located on the path where the command has been executed to the repository
     Push(RepoActionEnvArgs),
+
+    /// Changes the application's configuration settings.
+    Config(ConfigVariable),
 }
 
 #[derive(Clone, ValueEnum, Debug, Serialize)]
@@ -55,4 +48,15 @@ pub struct RepoActionEnvArgs {
 
     /// Environment where to find the .env file
     pub env: Environment,
+}
+
+#[derive(Args, Debug)]
+pub struct ConfigVariable {
+    /// A friendly name for identifying this configuration.
+    pub name: String,
+
+    #[clap(short, long)]
+    /// The full URL to the server.
+    /// If provided, it should be a valid URL format, e.g., "https://example.com".
+    pub url: Option<String>,
 }

--- a/cli/src/config_handler.rs
+++ b/cli/src/config_handler.rs
@@ -45,16 +45,19 @@ fn get_config_path() -> PathBuf {
     return config_path.clone();
 }
 
-pub fn get_config() -> Result<MoonenvConfig, ConfyError> {
-    // Construct the path to the configuration file
+fn get_config() -> Result<MoonenvConfig, ConfyError> {
     let config_path = get_config_path();
 
     return confy::load_path(config_path);
 }
 
+fn save_config(moonenv_config: MoonenvConfig) {
+    let config_path = get_config_path();
+    let _ = confy::store_path(config_path, moonenv_config);
+}
+
 pub fn change_config(new_config: IndividualConfig) -> Result<()> {
     let mut moonenv_config = get_config()?;
-    let config_path = get_config_path();
     let config_name = new_config.name.clone();
 
     if let Some(individual_config) = moonenv_config
@@ -70,9 +73,17 @@ pub fn change_config(new_config: IndividualConfig) -> Result<()> {
         moonenv_config.profile.push(new_config.clone());
     }
 
-    let _ = confy::store_path(config_path, moonenv_config);
+    save_config(moonenv_config);
 
-    println!("New config is set: {:?}", new_config);
+    Ok(())
+}
+
+pub fn set_default(name: String) -> Result<()> {
+    let mut moonenv_config = get_config()?;
+
+    moonenv_config.default = Some(name);
+
+    save_config(moonenv_config);
 
     Ok(())
 }

--- a/cli/src/config_handler.rs
+++ b/cli/src/config_handler.rs
@@ -1,0 +1,78 @@
+use anyhow::Result;
+use confy::{self, ConfyError};
+use serde::{Deserialize, Serialize};
+use std::{env, path::PathBuf};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MoonenvConfig {
+    pub default: Option<String>,
+
+    pub profile: Vec<IndividualConfig>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IndividualConfig {
+    pub url: Option<String>,
+
+    pub name: String,
+}
+
+impl Default for IndividualConfig {
+    fn default() -> Self {
+        Self {
+            name: "default".to_string(),
+            url: Some("www.moonenv.app".to_string()),
+        }
+    }
+}
+
+impl ::std::default::Default for MoonenvConfig {
+    fn default() -> Self {
+        Self {
+            default: Some("default".into()),
+            profile: vec![IndividualConfig::default()],
+        }
+    }
+}
+
+fn get_config_path() -> PathBuf {
+    let home = env::var("HOME").expect("HOME environment variable not set");
+    let mut config_path: PathBuf = PathBuf::from(home);
+
+    config_path.push(".moonenv");
+    config_path.push("config");
+
+    return config_path.clone();
+}
+
+pub fn get_config() -> Result<MoonenvConfig, ConfyError> {
+    // Construct the path to the configuration file
+    let config_path = get_config_path();
+
+    return confy::load_path(config_path);
+}
+
+pub fn change_config(new_config: IndividualConfig) -> Result<()> {
+    let mut moonenv_config = get_config()?;
+    let config_path = get_config_path();
+    let config_name = new_config.name.clone();
+
+    if let Some(individual_config) = moonenv_config
+        .profile
+        .iter_mut()
+        .find(|config| config.name == config_name)
+    {
+        match &new_config.url {
+            Some(url) => individual_config.url = Some(url.clone().to_string()),
+            None => {}
+        }
+    } else {
+        moonenv_config.profile.push(new_config.clone());
+    }
+
+    let _ = confy::store_path(config_path, moonenv_config);
+
+    println!("New config is set: {:?}", new_config);
+
+    Ok(())
+}

--- a/cli/src/config_handler.rs
+++ b/cli/src/config_handler.rs
@@ -7,7 +7,7 @@ use std::{env, path::PathBuf};
 pub struct MoonenvConfig {
     pub default: Option<String>,
 
-    pub profile: Vec<IndividualConfig>,
+    pub profiles: Vec<IndividualConfig>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -30,7 +30,7 @@ impl ::std::default::Default for MoonenvConfig {
     fn default() -> Self {
         Self {
             default: Some("default".into()),
-            profile: vec![IndividualConfig::default()],
+            profiles: vec![IndividualConfig::default()],
         }
     }
 }
@@ -61,7 +61,7 @@ pub fn change_config(new_config: IndividualConfig) -> Result<()> {
     let config_name = new_config.name.clone();
 
     if let Some(individual_config) = moonenv_config
-        .profile
+        .profiles
         .iter_mut()
         .find(|config| config.name == config_name)
     {
@@ -70,7 +70,7 @@ pub fn change_config(new_config: IndividualConfig) -> Result<()> {
             None => {}
         }
     } else {
-        moonenv_config.profile.push(new_config.clone());
+        moonenv_config.profiles.push(new_config.clone());
     }
 
     save_config(moonenv_config);
@@ -86,4 +86,24 @@ pub fn set_default(name: String) -> Result<()> {
     save_config(moonenv_config);
 
     Ok(())
+}
+
+fn get_default() -> Result<IndividualConfig> {
+    let moonenv_config = get_config()?;
+
+    let config = moonenv_config
+        .profiles
+        .iter()
+        .find(|config| Some(config.name.to_string()) == moonenv_config.default)
+        .expect("No default profile found. Ensure a default profile is correctly set in the configuration.");
+
+    Ok(config.clone())
+}
+
+pub fn get_default_url() -> Result<String> {
+    let config = get_default()?;
+
+    config.url.ok_or_else(|| {
+        anyhow::anyhow!("URL not configured in the default profile. Please set the URL to proceed.")
+    })
 }

--- a/cli/src/config_handler.rs
+++ b/cli/src/config_handler.rs
@@ -91,13 +91,11 @@ pub fn set_default(name: String) -> Result<()> {
 fn get_default() -> Result<IndividualConfig> {
     let moonenv_config = get_config()?;
 
-    let config = moonenv_config
+    return moonenv_config
         .profiles
         .iter()
         .find(|config| Some(config.name.to_string()) == moonenv_config.default)
-        .expect("No default profile found. Ensure a default profile is correctly set in the configuration.");
-
-    Ok(config.clone())
+        .ok_or_else(|| anyhow::anyhow!("No default profile found. Ensure a default profile is correctly set in the configuration.")).cloned();
 }
 
 pub fn get_default_url() -> Result<String> {

--- a/cli/src/env_handler.rs
+++ b/cli/src/env_handler.rs
@@ -1,4 +1,5 @@
 use crate::cli_struct::RepoActionEnvArgs;
+use crate::config_handler::get_default_url;
 use anyhow::{Context, Result};
 use base64::prelude::*;
 use reqwest::{header::CONTENT_TYPE, Client};
@@ -19,8 +20,12 @@ pub struct PullResponse {
 
 #[tokio::main]
 pub async fn pull_handler(value: RepoActionEnvArgs) -> Result<()> {
+    let url = get_default_url()?;
     let path = "./.env"; // TODO: Turn path as an optional field
-    let request_url = format!("https://t5m17jo2d8.execute-api.ap-southeast-2.amazonaws.com/dev/sendPullEnv?org={}&repo={}&env={}", value.org, value.repository, value.env);
+    let request_url = format!(
+        "{}/sendPullEnv?org={}&repo={}&env={}",
+        url, value.org, value.repository, value.env
+    );
     let response = Client::new().get(request_url).send().await?;
 
     response.error_for_status_ref()?;
@@ -39,9 +44,10 @@ pub async fn pull_handler(value: RepoActionEnvArgs) -> Result<()> {
 #[tokio::main]
 pub async fn push_handler(value: RepoActionEnvArgs) -> Result<()> {
     let path = "./.env"; // TODO: Turn path as an optional field
+    let url = get_default_url()?;
     let content =
         std::fs::read_to_string(path).with_context(|| format!("could not read file `{}`", path))?;
-    let request_url = "https://t5m17jo2d8.execute-api.ap-southeast-2.amazonaws.com/dev/sendPushEnv"; // TODO: Convert it to environment variable
+    let request_url = format!("{}/sendPushEnv", url);
     let request_body = json!({
         "org": value.org,
         "repo": value.repository,

--- a/cli/src/env_handler.rs
+++ b/cli/src/env_handler.rs
@@ -1,10 +1,21 @@
-use crate::cli_struct::{PullResponse, PushResponse, RepoActionEnvArgs};
+use crate::cli_struct::RepoActionEnvArgs;
 use anyhow::{Context, Result};
 use base64::prelude::*;
 use reqwest::{header::CONTENT_TYPE, Client};
+use serde::Deserialize;
 use serde_json::json;
 use std::fs::File;
 use std::io::Write;
+
+#[derive(Deserialize, Debug)]
+pub struct PushResponse {
+    pub message: String,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct PullResponse {
+    pub file: String,
+}
 
 #[tokio::main]
 pub async fn pull_handler(value: RepoActionEnvArgs) -> Result<()> {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,9 +1,11 @@
-use anyhow::Result;
+use anyhow::{Ok, Result};
 use clap::Parser;
 use cli_struct::{App, Command};
+use config_handler::{change_config, IndividualConfig};
 use env_handler::{pull_handler, push_handler};
 
 mod cli_struct;
+mod config_handler;
 mod env_handler;
 
 fn main() -> Result<()> {
@@ -12,6 +14,10 @@ fn main() -> Result<()> {
     match cli.command {
         Command::Pull(value) => pull_handler(value)?,
         Command::Push(value) => push_handler(value)?,
+        Command::Config(value) => change_config(IndividualConfig {
+            name: value.name,
+            url: value.url,
+        })?,
     }
 
     Ok(())

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Ok, Result};
 use clap::Parser;
-use cli_struct::{App, Command};
-use config_handler::{change_config, IndividualConfig};
+use cli_struct::{App, Command, ConfigVariableOptions};
+use config_handler::{change_config, set_default, IndividualConfig};
 use env_handler::{pull_handler, push_handler};
 
 mod cli_struct;
@@ -14,10 +14,13 @@ fn main() -> Result<()> {
     match cli.command {
         Command::Pull(value) => pull_handler(value)?,
         Command::Push(value) => push_handler(value)?,
-        Command::Config(value) => change_config(IndividualConfig {
-            name: value.name,
-            url: value.url,
-        })?,
+        Command::Config(config_subcommand) => match config_subcommand {
+            ConfigVariableOptions::Default(value) => set_default(value.name)?,
+            ConfigVariableOptions::Upsert(value) => change_config(IndividualConfig {
+                name: value.name,
+                url: value.url,
+            })?,
+        },
     }
 
     Ok(())


### PR DESCRIPTION
#6 

This PR will enable the `config` command. The user has to use `moonenv config <name> --url` to set different URLs for different profiles.
The config file is in the `~/.moonenv/config` directory:

```yml
default: default
profiles:
- url: www.moonenv.app
  name: default
- url: www.test.com.au
  name: test

```