### PR TITLE
Feature/add path option

### DIFF
--- a/cli/src/cli_struct.rs
+++ b/cli/src/cli_struct.rs
@@ -71,8 +71,8 @@ pub enum ConfigVariableOptions {
 
 #[derive(Args, Debug)]
 pub struct ConfigVariableUpsert {
-    /// A friendly name for identifying this configuration.
-    pub name: String,
+    /// The org identifier for this configuration.
+    pub org: String,
 
     #[clap(short, long)]
     /// The full URL to the server.

--- a/cli/src/cli_struct.rs
+++ b/cli/src/cli_struct.rs
@@ -39,10 +39,11 @@ impl fmt::Display for Environment {
     }
 }
 
-#[derive(Args, Debug)]
+#[derive(Args, Debug, Clone)]
 pub struct RepoActionEnvArgs {
+    #[clap(short, long)]
     /// The organization that owns the repository. Ensure that you have the necessary access permissions.
-    pub org: String,
+    pub org: Option<String>,
 
     /// The specific repository within the given organization where the `.env` file is located.
     pub repository: String,

--- a/cli/src/cli_struct.rs
+++ b/cli/src/cli_struct.rs
@@ -49,13 +49,12 @@ pub struct RepoActionEnvArgs {
 
     #[clap(short, long, default_value = "./.env")]
     /// Path to the environment variable file.
-    /// If unspecified, the default path used is `./.env`.
     pub path: std::path::PathBuf,
 
     /// The specific repository within the given organization where the `.env` file is located.
     pub repository: String,
 
-    /// Environment where to find the .env file
+    /// Environment where to find the .env file.
     pub env: Environment,
 }
 

--- a/cli/src/cli_struct.rs
+++ b/cli/src/cli_struct.rs
@@ -42,8 +42,15 @@ impl fmt::Display for Environment {
 #[derive(Args, Debug, Clone)]
 pub struct RepoActionEnvArgs {
     #[clap(short, long)]
-    /// The organization that owns the repository. Ensure that you have the necessary access permissions.
+    /// The organization that owns the repository.
+    /// Make sure you have the necessary access permissions.
+    /// If unspecified, the organization name is taken from the default configuration profile.
     pub org: Option<String>,
+
+    #[clap(short, long, default_value = "./.env")]
+    /// Path to the environment variable file.
+    /// If unspecified, the default path used is `./.env`.
+    pub path: std::path::PathBuf,
 
     /// The specific repository within the given organization where the `.env` file is located.
     pub repository: String,

--- a/cli/src/config_handler.rs
+++ b/cli/src/config_handler.rs
@@ -15,13 +15,13 @@ pub struct MoonenvConfig {
 pub struct IndividualConfig {
     pub url: Option<String>,
 
-    pub name: String,
+    pub org: String,
 }
 
 impl Default for IndividualConfig {
     fn default() -> Self {
         Self {
-            name: "default".to_string(),
+            org: "moonenv".to_string(),
             url: Some("www.moonenv.app".to_string()),
         }
     }
@@ -62,12 +62,12 @@ fn save_config(moonenv_config: MoonenvConfig) -> Result<()> {
 
 pub fn change_config(new_config: IndividualConfig) -> Result<()> {
     let mut moonenv_config = get_config()?;
-    let config_name = new_config.name.clone();
+    let config_name = new_config.org.clone();
 
     if let Some(individual_config) = moonenv_config
         .profiles
         .iter_mut()
-        .find(|config| config.name == config_name)
+        .find(|config| config.org == config_name)
     {
         match &new_config.url {
             Some(url) => individual_config.url = Some(url.clone().to_string()),
@@ -98,8 +98,14 @@ fn get_default() -> Result<IndividualConfig> {
     return moonenv_config
         .profiles
         .iter()
-        .find(|config| Some(config.name.to_string()) == moonenv_config.default)
+        .find(|config| Some(config.org.to_string()) == moonenv_config.default)
         .ok_or_else(|| anyhow::anyhow!("No default profile found. Ensure a default profile is correctly set in the configuration.")).cloned();
+}
+
+pub fn get_default_org() -> Result<String> {
+    let config = get_default()?;
+
+    Ok(config.org)
 }
 
 pub fn get_default_url() -> Result<String> {

--- a/cli/src/config_handler.rs
+++ b/cli/src/config_handler.rs
@@ -62,12 +62,12 @@ fn save_config(moonenv_config: MoonenvConfig) -> Result<()> {
 
 pub fn change_config(new_config: IndividualConfig) -> Result<()> {
     let mut moonenv_config = get_config()?;
-    let config_name = new_config.org.clone();
+    let config_org = new_config.org.clone();
 
     if let Some(individual_config) = moonenv_config
         .profiles
         .iter_mut()
-        .find(|config| config.org == config_name)
+        .find(|config| config.org == config_org)
     {
         match &new_config.url {
             Some(url) => individual_config.url = Some(url.clone().to_string()),

--- a/cli/src/env_handler.rs
+++ b/cli/src/env_handler.rs
@@ -1,5 +1,5 @@
 use crate::cli_struct::RepoActionEnvArgs;
-use crate::config_handler::get_default_url;
+use crate::config_handler::{get_default_org, get_default_url};
 use anyhow::{Context, Result};
 use base64::prelude::*;
 use reqwest::{header::CONTENT_TYPE, Client};
@@ -18,13 +18,21 @@ pub struct PullResponse {
     pub file: String,
 }
 
+fn get_org(value: RepoActionEnvArgs) -> Result<String> {
+    value
+        .org
+        .or(Some(get_default_org()?))
+        .ok_or_else(|| anyhow::anyhow!("Org parameter is missing"))
+}
+
 #[tokio::main]
 pub async fn pull_handler(value: RepoActionEnvArgs) -> Result<()> {
     let url = get_default_url()?;
+    let org = get_org(value.clone())?;
     let path = "./.env"; // TODO: Turn path as an optional field
     let request_url = format!(
         "{}/sendPullEnv?org={}&repo={}&env={}",
-        url, value.org, value.repository, value.env
+        url, org, value.repository, value.env
     );
     let response = Client::new().get(request_url).send().await?;
 
@@ -45,11 +53,12 @@ pub async fn pull_handler(value: RepoActionEnvArgs) -> Result<()> {
 pub async fn push_handler(value: RepoActionEnvArgs) -> Result<()> {
     let path = "./.env"; // TODO: Turn path as an optional field
     let url = get_default_url()?;
+    let org = get_org(value.clone())?;
     let content =
         std::fs::read_to_string(path).with_context(|| format!("could not read file `{}`", path))?;
     let request_url = format!("{}/sendPushEnv", url);
     let request_body = json!({
-        "org": value.org,
+        "org": org,
         "repo": value.repository,
         "env": value.env,
         "b64String": BASE64_STANDARD.encode(content)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
         Command::Config(config_subcommand) => match config_subcommand {
             ConfigVariableOptions::Default(value) => set_default(value.name)?,
             ConfigVariableOptions::Upsert(value) => change_config(IndividualConfig {
-                org: value.name,
+                org: value.org,
                 url: value.url,
             })?,
         },

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ fn main() -> Result<()> {
         Command::Config(config_subcommand) => match config_subcommand {
             ConfigVariableOptions::Default(value) => set_default(value.name)?,
             ConfigVariableOptions::Upsert(value) => change_config(IndividualConfig {
-                name: value.name,
+                org: value.name,
                 url: value.url,
             })?,
         },


### PR DESCRIPTION
#14 

It adds 2 args: `path` and `org`;
`org`, which was a required parameter is now an optional field; by default, it looks to the value set on the default profile;
renamed the `name` field on the config file to `org`; 